### PR TITLE
Make react native a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "DaniAkash <s.daniakash@gmail.com> (https://github.com/DaniAkash)",
   "repository": "DaniAkash/react-native-responsive-dimensions",
   "license": "MIT",
-  "dependencies": {
+  "peerDependencies": {
     "react-native": "x"
   }
 }


### PR DESCRIPTION
Originally could cause `@providesModule` naming collision by installing a duplicate copy of react native.