### PR TITLE
update peerDependencies to use any version of react-native >= 0.44.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "react-native-responsive-dimensions",
   "version": "1.0.2",
-  "description": "Resposive fontSize, height and width for your react-native components.",
+  "description":
+    "Resposive fontSize, height and width for your react-native components.",
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",
@@ -20,6 +21,6 @@
   "repository": "DaniAkash/react-native-responsive-dimensions",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "x"
+    "react-native": ">=0.44.1"
   }
 }


### PR DESCRIPTION
- Should use any version of `react-native >= 0.44.1` because that was the last version where the Dimensions API had major changes.
- When you specify a `peerDependency` as `react-native@x` you lock the version of react-native required to use the package and so instead of using `"react-native": ">=x"` or use a specific version as the baseline such as `"react-native": ">= 0.44.1"`.
- This change thus ensures that your react-native projects don't raise `@providesModule naming collision` warnings or `Duplicate module name: react-native` errors after upgrading your project using the `react-native-git-upgrade` CLI.