### PR TITLE
remove warning like "EventEmitter.removeListener('change', ...): Method has been deprecated."

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,9 +21,9 @@ const useDimensionsListener = () => {
       setScreenDimension(screen);
     }
 
-    Dimensions.addEventListener("change", handleDimensionChange);
+    let handleDimensionChangeLinstener = Dimensions.addEventListener("change", handleDimensionChange);
     return () => {
-      Dimensions.removeEventListener("change", handleDimensionChange);
+      handleDimensionChangeLinstener.remove();
     };
   }, []);
 


### PR DESCRIPTION
Since EventEmitter.removeListener('change', ...): Method has been deprecated. Please instead use `remove()` on the subscription returned by `EventEmitter.addListener`.