### PR TITLE
fix: effect callback called on each render when dimensions have not changed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ export const useDimensionsChange = (effect: EffectCallback) => {
     } else {
       hasMountRef.current = true;
     }
-  }, [dimensions, effect]);
+  }, [dimensions.screen, dimensions.window, effect]);
 };
 
 export const responsiveHeight = (h: number) => {


### PR DESCRIPTION
The hook `useDimensionsListener` returns a new object. This results in the hook `useDimensionsChange` to always call the `effect` callback on each render since `useDimensionsListener()` returns a new object each time.

This PR fixes this by using the screen and window properties explicitly as the dependencies for `useEffect`.
